### PR TITLE
Update nbviewer version to e6591a2

### DIFF
--- a/config/nbviewer.yaml
+++ b/config/nbviewer.yaml
@@ -1,6 +1,6 @@
 replicas: 3
 
-image: jupyter/nbviewer:68472ab
+image: jupyter/nbviewer:e6591a2
 
 memcached:
   config:


### PR DESCRIPTION
- Updates nbviewer chart to jupyter/nbviewer@e6591a2c29cd150b4881fd23ba865100bcd63634
- Update nbviewer image to `e6591a2`



## Related

- Source code: https://github.com/jupyter/nbviewer